### PR TITLE
fix: Update TypeScript configurations and types

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,3 +8,6 @@ name = "javascript"
     "jest",
     "nodejs"
   ]
+
+[[transformers]]
+name = "prettier"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,8 @@
-import globals from 'globals'
-import pluginJs from '@eslint/js'
-import tseslint from 'typescript-eslint'
+const globals = require('globals')
+const pluginJs = require('@eslint/js')
+const tseslint = require('typescript-eslint')
 
-/** @type {import('eslint').Linter.Config[]} */
-export default [
+module.exports = [
     { files: ['**/*.{js,mjs,cjs,ts}'] },
     { languageOptions: { globals: globals.browser } },
     pluginJs.configs.recommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,4 +8,9 @@ export default [
     { languageOptions: { globals: globals.browser } },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,
+    {
+        rules: {
+            '@typescript-eslint/no-explicit-any': 'off',
+        },
+    },
 ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
-export default {
+module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     roots: ['<rootDir>/tests'],

--- a/src/call/index.ts
+++ b/src/call/index.ts
@@ -29,7 +29,7 @@ import { Error } from '../frappe/types'
 
 /** Base response type for Frappe API calls */
 export interface FrappeResponse {
-    message: unknown
+    message: any
 }
 
 /**

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -128,7 +128,7 @@ export class FrappeDB {
      * const task = await db.getDoc('Task', 'TASK-001');
      * ```
      */
-    async getDoc<T = object>(doctype: string, docname: string = ''): Promise<FrappeDoc<T>> {
+    async getDoc<T = object>(doctype: string, docname = ''): Promise<FrappeDoc<T>> {
         return this.axios
             .get(`/api/resource/${doctype}/${encodeURIComponent(docname)}`)
             .then((res) => res.data.data)
@@ -339,13 +339,8 @@ export class FrappeDB {
      * );
      * ```
      */
-    async getCount<T = object>(
-        doctype: string,
-        filters?: Filter<T>[],
-        cache: boolean = false,
-        debug: boolean = false,
-    ): Promise<number> {
-        const params: Record<string, unknown> = {
+    async getCount<T = object>(doctype: string, filters?: Filter<T>[], cache = false, debug = false): Promise<number> {
+        const params: Record<string, any> = {
             doctype,
             filters: [],
         }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -355,7 +355,6 @@ export class FrappeDB {
         if (filters) {
             params.filters = filters ? JSON.stringify(filters) : undefined
         }
-
         return this.axios
             .get('/api/method/frappe.client.get_count', { params })
             .then((res) => res.data.message)

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -24,7 +24,7 @@
  * ```
  */
 
-import { AxiosInstance } from 'axios'
+import { AxiosError, AxiosInstance } from 'axios'
 
 import { Error } from '../frappe/types'
 import { Filter, FrappeDoc, GetDocListArgs, GetLastDocArgs } from './types'
@@ -355,18 +355,21 @@ export class FrappeDB {
         if (filters) {
             params.filters = filters ? JSON.stringify(filters) : undefined
         }
-        return this.axios
-            .get('/api/method/frappe.client.get_count', { params })
-            .then((res) => res.data.message)
-            .catch((error) => {
-                throw {
-                    ...error.response.data,
-                    httpStatus: error.response.status,
-                    httpStatusText: error.response.statusText,
-                    message: 'There was an error while getting the count.',
-                    exception: error.response.data.exception ?? error.response.data.exc_type ?? '',
-                } as Error
-            })
+
+        try {
+            const res = await this.axios.get('/api/method/frappe.client.get_count', { params })
+            return res.data.message
+        } catch (error) {
+            const axiosError = error as AxiosError<{ exception?: string; exc_type?: string }>
+
+            throw {
+                ...axiosError.response?.data,
+                httpStatus: axiosError.response?.status,
+                httpStatusText: axiosError.response?.statusText,
+                message: 'There was an error while getting the count.',
+                exception: axiosError.response?.data?.exception ?? axiosError.response?.data?.exc_type ?? '',
+            } as Error
+        }
     }
 
     /**

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -161,7 +161,7 @@ export class FrappeFileUpload {
         file: File,
         args: FileArgs,
         onProgress?: (bytesUploaded: number, totalBytes?: number, progress?: AxiosProgressEvent) => void,
-        apiPath: string = 'upload_file',
+        apiPath = 'upload_file',
     ) {
         const formData = new FormData()
         if (file) formData.append('file', file, file.name)

--- a/src/file/types.ts
+++ b/src/file/types.ts
@@ -12,7 +12,7 @@
 export interface FileMetadata {
     description?: string
     tags?: string[]
-    [key: string]: unknown
+    [key: string]: any
 }
 
 /** Configuration options for file upload operations */

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -106,7 +106,7 @@ export function getAxiosClient(
  * @internal
  */
 export function getRequestHeaders(
-    useToken: boolean = false,
+    useToken = false,
     tokenType?: 'Bearer' | 'token',
     token?: () => string,
     appURL?: string,

--- a/tests/axios.test.ts
+++ b/tests/axios.test.ts
@@ -15,13 +15,13 @@ describe('Axios Utils', () => {
                 hostname: 'test.example.com',
             },
             csrf_token: 'test-csrf-token',
-        } as unknown as Window & typeof globalThis
+        } as any as Window & typeof globalThis
 
         global.document = {
             querySelector: jest.fn(() => ({
                 getAttribute: jest.fn().mockReturnValue('test-csrf-token'),
             })),
-        } as unknown as Document
+        } as any as Document
     })
 
     describe('getAxiosClient', () => {
@@ -85,7 +85,7 @@ describe('Axios Utils', () => {
                     hostname: 'test.example.com',
                 },
                 csrf_token: 'test-csrf-token',
-            } as unknown as Window & typeof globalThis
+            } as any as Window & typeof globalThis
         })
 
         afterEach(() => {
@@ -139,7 +139,7 @@ describe('Axios Utils', () => {
         })
 
         it('should return undefined when document is not defined', () => {
-            global.document = undefined as unknown as Document
+            global.document = undefined as any as Document
             expect(getCSRFToken()).toBeUndefined()
         })
 
@@ -149,7 +149,7 @@ describe('Axios Utils', () => {
             }
             global.document = {
                 querySelector: jest.fn().mockReturnValue(mockMetaElement),
-            } as unknown as Document
+            } as any as Document
 
             expect(getCSRFToken()).toBe('test-csrf-token')
         })
@@ -157,7 +157,7 @@ describe('Axios Utils', () => {
         it('should return undefined when meta tag is not found', () => {
             global.document = {
                 querySelector: jest.fn().mockReturnValue(null),
-            } as unknown as Document
+            } as any as Document
 
             expect(getCSRFToken()).toBeUndefined()
         })
@@ -168,7 +168,7 @@ describe('Axios Utils', () => {
             }
             global.document = {
                 querySelector: jest.fn().mockReturnValue(mockMetaElement),
-            } as unknown as Document
+            } as any as Document
 
             expect(getCSRFToken()).toBeUndefined()
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,9 +1890,9 @@ ejs@^3.1.10:
     jake "^10.8.5"
 
 electron-to-chromium@^1.5.73:
-  version "1.5.116"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.116.tgz#b779d73cd0cc75305d12ae4f061d7f7bcee4c761"
-  integrity sha512-mufxTCJzLBQVvSdZzX1s5YAuXsN1M4tTyYxOOL1TcSKtIzQ9rjIrm7yFK80rN5dwGTePgdoABDSHpuVtRQh0Zw==
+  version "1.5.118"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.118.tgz#064bda9bfea1611074288adb1fdd1f787a131e21"
+  integrity sha512-yNDUus0iultYyVoEFLnQeei7LOQkL8wg8GQpkPCRrOlJXlcCwa6eGKZkxQ9ciHsqZyYbj8Jd94X1CTPzGm+uIA==
 
 emittery@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
- Disabled the '@typescript-eslint/no-explicit-any' rule in ESLint configuration.
- Changed type of 'message' in FrappeResponse interface from 'unknown' to 'any'.
- Updated 'getDoc' and 'getCount' methods in FrappeDB class to use default parameter syntax.
- Modified 'FileMetadata' interface to use 'any' instead of 'unknown' for dynamic keys.
- Adjusted type assertions in axios tests from 'unknown' to 'any' for better compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated linting settings to allow more flexible type usage.
  - Added a new transformer for Prettier in the configuration.
- **Refactor**
  - Simplified default parameter syntax and type declarations for improved internal consistency.
- **Tests**
  - Refined type assertions for enhanced clarity in the testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->